### PR TITLE
enable multiple recipients for sending email

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ TRANSACTIONS_MONGODB_URL      | &#x2713; | mongodb://localhost:27017/|        | 
 TRANSACTIONS_MONGODB_DATABASE | &#x2713; | users_application         |        |
 LOG_LEVEL                     | &#x2717; | debug                     | info   | A lower case representation of the standard log level enumerations. Possible values can be found [here](https://github.com/sirupsen/logrus/blob/master/logrus.go#L25)
 SENDER_EMAIL                  | &#x2713; | example@provider.co.uk    |        | This variable must be on the AWS authorised list
-RECEIVER_EMAIL                | &#x2713; | example@provider.co.uk    |        | This variable must be on the AWS authorised list
+RECEIVER_EMAILS               | &#x2713; | example@provider.co.uk,another@provider.co.uk    |        | These variables must be on the AWS authorised list and be separated by commas with no spaces
 SES_AWS_REGION                | &#x2713; | eu-west-1                 |        | This variable must be a valid AWS region
 
 ### Building and running

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	TransactionsMongoDBDatabase string `env:"TRANSACTIONS_MONGODB_DATABASE"  flag:"transactions-mongodb-database"  flagDesc:"Transactions MongoDB database for data"`
 	LogLevel                    string `env:"LOG_LEVEL"                      flag:"log-level"                      flagDesc:"Logging level of the application"`
 	SenderEmail                 string `env:"SENDER_EMAIL"                   flag:"sender-email"                   flagDesc:"Email of Sender"`
-	ReceiverEmail               string `env:"RECEIVER_EMAIL"                 flag:"receiver-email"                 flagDesc:"Email of Receiver"`
+	ReceiverEmails              string `env:"RECEIVER_EMAILS"                flag:"receiver-emails"                flagDesc:"Emails of each Receiver"`
 	SesAwsRegion                string `env:"SES_AWS_REGION"                 flag:"ses-aws-region"                 flagDesc:"AWS Region"`
 }
 
@@ -57,8 +57,8 @@ func Get() (*Config, error) {
 		mandatoryConfigsMissing = true
 	}
 
-	if cfg.ReceiverEmail == "" {
-		log.Warn("RECEIVER_EMAIL not set in environment")
+	if cfg.ReceiverEmails == "" {
+		log.Warn("RECEIVER_EMAILS not set in environment")
 		mandatoryConfigsMissing = true
 	}
 


### PR DESCRIPTION
Enable environment variables too now accept multiple receiver emails so that an email can be sent to multiple people at once.